### PR TITLE
add track/device pinning

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,8 +63,8 @@ A Bitwig Studio controller extension for the
 | ---- | --------------------------- | ------------------------- | --------------- | ------------------------- | -------------------- |
 | 1    | Select track                | Toggle mute               | -               | Toggle arm                | Follow track color   |
 | 2    | Track volume                | Toggle fine sensitivity   | Reset volume    | Toggle Solo               | Follow track color   |
-| 3    | Track pan                   | Toggle sensitivity        | Reset pan       | -                         | Follow track color   |
-| 4    | Current send volume         | Cycle through track sends | -               | -                         | Follow send color    |
+| 3    | Track pan                   | Toggle sensitivity        | Reset pan       | Toggle track pinning      | Pinned status        |
+| 4    | Current send volume         | Cycle through track sends | -               | Toggle device pinning     | Follow send color    |
 | 5    | Select device               | Toggle enable             | -               | Toggle expand             | Device row color     |
 | 6    | Select remote controls page | Show/hide device UI       | -               | Show/Hide remote controls | Device row color     |
 | 7    | Specific device parameter 1 | Toggle fine sensitivity   | Reset parameter | Insert device before      | Device row color     |
@@ -74,6 +74,12 @@ A Bitwig Studio controller extension for the
 #### Notes
 
 - The color palette on the Twister is very limited. Colors are matched as closely as possible.
+
+- Pinned colors:
+  - OFF: nothing
+  - RED: track is pinned
+  - YELLOW: device is pinned
+  - GREEN: both track and device are pinned
 
 - If a device or parameter does not exist in the current context then the corresponding lights will
   be off.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>twister-sister</artifactId>
   <packaging>jar</packaging>
   <name>Twister Sister</name>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/io/github/dozius/TwisterSisterExtensionDefinition.java
+++ b/src/main/java/io/github/dozius/TwisterSisterExtensionDefinition.java
@@ -47,7 +47,7 @@ public class TwisterSisterExtensionDefinition extends ControllerExtensionDefinit
   @Override
   public String getVersion()
   {
-    return "1.0.1";
+    return "1.1.0";
   }
 
   @Override


### PR DESCRIPTION
Add support for track/device pinning (long press on knobs 3-4), with color indication on knob 3.

Not ergonomically ideal, just working within confines of the existing mapping.