### PR TITLE
Fix antlr conflicts with Bitwig v5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.tomlj</groupId>
       <artifactId>tomlj</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.0</version>
     </dependency>
   </dependencies>
 
@@ -107,7 +107,7 @@
         </configuration>
       </plugin>
 
-      <!-- Package all dependecies except for the Bitwig API -->
+      <!-- Package dependecies -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -121,6 +121,7 @@
             <configuration>
               <artifactSet>
                 <excludes>
+                  <!-- Exclude Bitwig API -->
                   <exclude>com.bitwig:extension-api</exclude>
                 </excludes>
               </artifactSet>
@@ -133,6 +134,13 @@
                   </excludes>
                 </filter>
               </filters>
+              <relocations>
+                <relocation>
+                  <!-- Relocate Antlr to avoid conflicts with Bitwig -->
+                  <pattern>org.antlr</pattern>
+                  <shadedPattern>org.tomlj.internal.antlr</shadedPattern>
+                </relocation>
+              </relocations>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/io/github/dozius/TwisterSisterExtensionDefinition.java
+++ b/src/main/java/io/github/dozius/TwisterSisterExtensionDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Dan Smith
+ * Copyright 2021-2023 Dan Smith
  *
  * This file is part of Twister Sister.
  *


### PR DESCRIPTION
- Update tomlj to 1.1.0

- Relocate antlr during build because the supposed fixed artifact from tomlj doesn't exist on maven. ¯\\\_(ツ)\_/¯