### PR TITLE
Fix crash when a device list is missing from specific device settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>twister-sister</artifactId>
   <packaging>jar</packaging>
   <name>Twister Sister</name>
-  <version>2.0.1</version>
+  <version>2.0.2</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/io/github/dozius/TwisterSisterExtension.java
+++ b/src/main/java/io/github/dozius/TwisterSisterExtension.java
@@ -511,6 +511,10 @@ public class TwisterSisterExtension extends ControllerExtension
                                                                                                   TwisterKnob knob,
                                                                                                   OnOffColorSupplier colorSupplier)
   {
+    if (settings == null) {
+      return;
+    }
+
     for (final SettingType setting : settings) {
       if (setting.parameters().get(key) == null) {
         continue;

--- a/src/main/java/io/github/dozius/TwisterSisterExtensionDefinition.java
+++ b/src/main/java/io/github/dozius/TwisterSisterExtensionDefinition.java
@@ -47,7 +47,7 @@ public class TwisterSisterExtensionDefinition extends ControllerExtensionDefinit
   @Override
   public String getVersion()
   {
-    return "2.0.1";
+    return "2.0.2";
   }
 
   @Override


### PR DESCRIPTION
If any of the device lists (bitwig, vst2, vst3) were empty or missing from the config file it would result in a crash if parameters had been defined for either knob1 or knob2.